### PR TITLE
properly escape the new `ArrayBuffer` typemap

### DIFF
--- a/CHANGES-JSE
+++ b/CHANGES-JSE
@@ -7,7 +7,7 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 5.0.3
 ===========================
 
-2024-02-28: mmomtchev
+2024-02-29: mmomtchev
             [JavaScript] Fix [mmomtchev/swig#31](https://github.com/mmomtchev/swig/issues/31),
             the `ArrayBuffer` tmap is missing the `emnapi` synchronization
             unless `-D__EMSCRIPTEN__` is passed when running SWIG

--- a/CHANGES-JSE
+++ b/CHANGES-JSE
@@ -4,6 +4,14 @@ See the RELEASENOTES file for a summary of changes in each release.
 Issue # numbers mentioned below can be found on Github. For more details, add
 the issue number to the end of the URL: https://github.com/swig/swig/issues/
 
+Version 5.0.3
+===========================
+
+2024-02-28: mmomtchev
+            [JavaScript] Fix [mmomtchev/swig#31](https://github.com/mmomtchev/swig/issues/31),
+            the `ArrayBuffer` tmap is missing the `emnapi` synchronization
+            unless `-D__EMSCRIPTEN__` is passed when running SWIG
+
 Version 5.0.2
 ===========================
 

--- a/Examples/test-suite/director_thread.i
+++ b/Examples/test-suite/director_thread.i
@@ -106,7 +106,7 @@ extern "C" {
     }
 
     void setThreadName() {
-%#if defined(_WIN32) || defined(SWIG_EMSCRIPTEN)
+%#if defined(_WIN32) || defined(__EMSCRIPTEN__)
     // https://github.com/emscripten-core/emscripten/pull/18751
 %#else
 

--- a/Examples/test-suite/director_thread.i
+++ b/Examples/test-suite/director_thread.i
@@ -106,7 +106,7 @@ extern "C" {
     }
 
     void setThreadName() {
-%#if defined(_WIN32) || defined(__EMSCRIPTEN__)
+%#if defined(_WIN32) || defined(SWIG_EMSCRIPTEN)
     // https://github.com/emscripten-core/emscripten/pull/18751
 %#else
 
@@ -125,7 +125,7 @@ extern "C" {
     }
 
     static bool namedThread() {
-%#if defined(_WIN32) || defined(__EMSCRIPTEN__)
+%#if defined(_WIN32) || defined(SWIG_EMSCRIPTEN)
       return false;
 %#else
       return true;

--- a/Examples/test-suite/javascript/Makefile.in
+++ b/Examples/test-suite/javascript/Makefile.in
@@ -106,7 +106,7 @@ ifeq (emcc, $(CC))
         endif
   	GYP_CXXFLAGS = -I@NODENAPI_DIR@
   	GYP_TEMPLATE = wasm_template
-  	SWIGOPT += -D__EMSCRIPTEN__
+  	SWIGOPT += -DSWIG_EMSCRIPTEN
   	EMNAPI_LIB = -lemnapi
 # Some emscripten-specific warnings on certain tests
 cpp11_lambda_functions.cpptest: GYP_CFLAGS = \"-Wno-unused-lambda-capture\",

--- a/Examples/test-suite/register_par.i
+++ b/Examples/test-suite/register_par.i
@@ -6,7 +6,7 @@ struct swig_tree;
 
 %{
 #if defined(__cplusplus)
-#if __cplusplus >= 201703L || defined(SWIG_EMSCRIPTEN)
+#if __cplusplus >= 201703L || defined(__EMSCRIPTEN__)
 /*
 Fix for languages that compile C tests as C++:
   error: ISO C++17 does not allow ‘register’ storage class specifier [-Werror=register]

--- a/Examples/test-suite/register_par.i
+++ b/Examples/test-suite/register_par.i
@@ -6,7 +6,7 @@ struct swig_tree;
 
 %{
 #if defined(__cplusplus)
-#if __cplusplus >= 201703L || defined(__EMSCRIPTEN__)
+#if __cplusplus >= 201703L || defined(SWIG_EMSCRIPTEN)
 /*
 Fix for languages that compile C tests as C++:
   error: ISO C++17 does not allow ‘register’ storage class specifier [-Werror=register]

--- a/Lib/javascript/napi/arraybuffer.i
+++ b/Lib/javascript/napi/arraybuffer.i
@@ -55,7 +55,7 @@
   $1 = &temp_data;
   $2 = &temp_len;
 }
-%typemap(argout) RETURN_NEW_BUFFER_SIGNATURE {
+%typemap(argout) RETURN_NEW_BUFFER_SIGNATURE %{
   if (*$1 != SWIG_NULLPTR) {
     Napi::ArrayBuffer buf = Napi::ArrayBuffer::New(env, *$2);
     memcpy(buf.Data(), *$1, *$2);
@@ -67,7 +67,7 @@
   } else {
     $result = env.Null();
   }
-}
+%}
 
 /**
  * Writable ArrayBuffer in arguments.

--- a/Lib/javascript/napi/arraybuffer.i
+++ b/Lib/javascript/napi/arraybuffer.i
@@ -34,7 +34,7 @@
   }
 }
 
-%typemap(typecheck, precedence=SWIG_TYPECHECK_VOIDPTR) (const void* arraybuffer_data, const size_t arraybuffer_len) {
+%typemap(typecheck, precedence=SWIG_TYPECHECK_VOIDPTR) READONLY_BUFFER_SIGNATURE {
   $1 = $input.IsArrayBuffer();
 }
 


### PR DESCRIPTION
Escape he new `ArrayBuffer` typemap
Use a different emscripten macro when generating the wrappers to prevent masking of macro escape problems

Fixes #31 