### PR TITLE
remove the hidden built-in method for retrieving the raw C pointer

### DIFF
--- a/CHANGES-JSE
+++ b/CHANGES-JSE
@@ -7,6 +7,10 @@ the issue number to the end of the URL: https://github.com/swig/swig/issues/
 Version 5.0.5
 ===========================
 
+2024-09-08: mmomtchev
+            [JavaScript] Fix [mmomtchev/swig#37](https://github.com/mmomtchev/swig/issues/37),
+            Generated code compilation fails with `clang` on Windows
+
 2024-09-01: mmomtchev
             [JavaScript] Fix [mmomtchev/swig#62](https://github.com/mmomtchev/swig/issues/62),
             eliminate `$argnum` from JavaScript C-style array typemaps

--- a/Lib/javascript/napi/javascriptrunbody.swg
+++ b/Lib/javascript/napi/javascriptrunbody.swg
@@ -343,29 +343,6 @@ fail:
 #endif
 }
 
-SWIGRUNTIME Napi::Value _wrap_getCPtr(const Napi::CallbackInfo &info) {
-  Napi::Env env = info.Env();
-  Napi::Value jsresult;
-  void *arg1 = (void *) 0 ;
-  long result;
-  int res1;
-
-  res1 = SWIG_GetInstancePtr(info.This(), &arg1);
-  if (!SWIG_IsOK(res1)) {
-    SWIG_Error(SWIG_ArgError(res1), " in method '" "getCPtr" "', argument " "1"" of type '" "void *""'");
-  }
-
-  result = (long)arg1;
-  jsresult = Napi::Number::New(env, result);
-
-  return jsresult;
-#ifndef NAPI_CPP_EXCEPTIONS
-  goto fail;
-fail:
-  return Napi::Value();
-#endif
-}
-
 /* ---------------------------------------------------------------------------
  * PackedData object
  * (objects visible to JS that do not have a dedicated wrapper but must preserve type)


### PR DESCRIPTION
There is no better fix since if the raw C pointer can point beyond the max safe integer in JavaScript

This method is a left-over from the raw V8 implementation and it is not used in Node-API

Fixes #37 